### PR TITLE
Fix PR runs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,14 +2,16 @@ set -e
 
 # Unfortunately, the GitHub Actions Marketplace strips out all Git details
 # (including submodules) on publish, so we have to re-clone our own repository
-# to get the avra submodule we plan to build.
+# to get the AVRA submodule we plan to build.
 
-NEOMURA_SETUP_AVRA_CLI_ACTION_BRANCH=${NEOMURA_SETUP_AVRA_CLI_ACTION_REF#refs/heads/}
-NEOMURA_SETUP_AVRA_CLI_ACTION_BRANCH=${NEOMURA_SETUP_AVRA_CLI_ACTION_BRANCH#refs/tags/}
-
-git clone https://github.com/$NEOMURA_SETUP_AVRA_CLI_ACTION_REPOSITORY --branch $NEOMURA_SETUP_AVRA_CLI_ACTION_BRANCH --depth 1 clone
-
+mkdir clone
 cd clone
+
+git init
+git remote add origin https://github.com/$NEOMURA_SETUP_AVRA_CLI_ACTION_REPOSITORY
+git fetch origin $NEOMURA_SETUP_AVRA_CLI_ACTION_REF:temp
+git checkout temp
+
 git submodule update --init --recursive submodules/Ro5bert/avra
 
 cd submodules


### PR DESCRIPTION
The hack currently in place to pull down the appropriate branch doesn't work when there is no branch, such as when GitHub creates a temporary ref to represent the result of merging a PR.